### PR TITLE
Fixes indexer binary

### DIFF
--- a/cmd/elasticindexer/flags.go
+++ b/cmd/elasticindexer/flags.go
@@ -35,4 +35,10 @@ var (
 		Name:  "disable-ansi-color",
 		Usage: "Boolean option for disabling ANSI colors in the logging system.",
 	}
+	importDB = cli.BoolFlag{
+		Name: "import-db",
+		Usage: "This flag, when enabled, triggers the indexer to operate in import database mode. In this mode," +
+			" the indexer excludes the indexing of cross shard transactions received from the source shard. " +
+			"This flag must be enabled when the observers are in import database mode.",
+	}
 )

--- a/cmd/elasticindexer/main.go
+++ b/cmd/elasticindexer/main.go
@@ -67,22 +67,22 @@ func main() {
 func startIndexer(ctx *cli.Context) error {
 	cfg, err := loadMainConfig(ctx.GlobalString(configurationFile.Name))
 	if err != nil {
-		return err
+		return fmt.Errorf("%w while loading the config file", err)
 	}
 
 	clusterCfg, err := loadClusterConfig(ctx.GlobalString(configurationPreferencesFile.Name))
 	if err != nil {
-		return err
+		return fmt.Errorf("%w while loading the preferences config file", err)
 	}
 
 	fileLogging, err := initializeLogger(ctx, cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w while initializing the logger", err)
 	}
 
 	wsHost, err := factory.CreateWsIndexer(cfg, clusterCfg)
 	if err != nil {
-		log.Error("cannot create ws indexer", "error", err)
+		return fmt.Errorf("%w while creating the indexer", err)
 	}
 
 	interrupt := make(chan os.Signal, 1)

--- a/cmd/elasticindexer/main.go
+++ b/cmd/elasticindexer/main.go
@@ -47,6 +47,7 @@ func main() {
 		logLevel,
 		logSaveFile,
 		disableAnsiColor,
+		importDB,
 	}
 	app.Authors = []cli.Author{
 		{
@@ -80,7 +81,8 @@ func startIndexer(ctx *cli.Context) error {
 		return fmt.Errorf("%w while initializing the logger", err)
 	}
 
-	wsHost, err := factory.CreateWsIndexer(cfg, clusterCfg)
+	importDBMode := ctx.GlobalBool(importDB.Name)
+	wsHost, err := factory.CreateWsIndexer(cfg, clusterCfg, importDBMode)
 	if err != nil {
 		return fmt.Errorf("%w while creating the indexer", err)
 	}

--- a/factory/wsIndexerFactory.go
+++ b/factory/wsIndexerFactory.go
@@ -20,13 +20,13 @@ const (
 var log = logger.GetOrCreate("elasticindexer")
 
 // CreateWsIndexer will create a new instance of wsindexer.WSClient
-func CreateWsIndexer(cfg config.Config, clusterCfg config.ClusterConfig) (wsindexer.WSClient, error) {
+func CreateWsIndexer(cfg config.Config, clusterCfg config.ClusterConfig, importDB bool) (wsindexer.WSClient, error) {
 	wsMarshaller, err := factoryMarshaller.NewMarshalizer(clusterCfg.Config.WebSocket.DataMarshallerType)
 	if err != nil {
 		return nil, err
 	}
 
-	dataIndexer, err := createDataIndexer(cfg, clusterCfg, wsMarshaller)
+	dataIndexer, err := createDataIndexer(cfg, clusterCfg, wsMarshaller, importDB)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func CreateWsIndexer(cfg config.Config, clusterCfg config.ClusterConfig) (wsinde
 	return host, nil
 }
 
-func createDataIndexer(cfg config.Config, clusterCfg config.ClusterConfig, wsMarshaller marshal.Marshalizer) (wsindexer.DataIndexer, error) {
+func createDataIndexer(cfg config.Config, clusterCfg config.ClusterConfig, wsMarshaller marshal.Marshalizer, importDB bool) (wsindexer.DataIndexer, error) {
 	marshaller, err := factoryMarshaller.NewMarshalizer(cfg.Config.Marshaller.Type)
 	if err != nil {
 		return nil, err
@@ -81,6 +81,7 @@ func createDataIndexer(cfg config.Config, clusterCfg config.ClusterConfig, wsMar
 		AddressPubkeyConverter:   addressPubkeyConverter,
 		ValidatorPubkeyConverter: validatorPubkeyConverter,
 		HeaderMarshaller:         wsMarshaller,
+		ImportDB:                 importDB,
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.12.0
 	github.com/multiversx/mx-chain-communication-go v0.0.0-20230512095548-5bc637293104
-	github.com/multiversx/mx-chain-core-go v1.2.1-0.20230511072341-83cfe4713dac
+	github.com/multiversx/mx-chain-core-go v1.2.4-0.20230517135533-2e54a17cd912
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-chain-vm-common-go v1.4.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/multiversx/mx-chain-communication-go v0.0.0-20230512095548-5bc6372931
 github.com/multiversx/mx-chain-core-go v1.1.30/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/multiversx/mx-chain-core-go v1.2.0/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/multiversx/mx-chain-core-go v1.2.1-0.20230510143029-ab37792342df/go.mod h1:jzYFSiYBuO0dGpGFXnZWSwcwcKP7Flyn/X41y4zIQrQ=
-github.com/multiversx/mx-chain-core-go v1.2.1-0.20230511072341-83cfe4713dac h1:cueVlh2q3oO6reSZndgBEv/VL9xkaCgvPedo1ADqohg=
-github.com/multiversx/mx-chain-core-go v1.2.1-0.20230511072341-83cfe4713dac/go.mod h1:jzYFSiYBuO0dGpGFXnZWSwcwcKP7Flyn/X41y4zIQrQ=
+github.com/multiversx/mx-chain-core-go v1.2.4-0.20230517135533-2e54a17cd912 h1:7dgFuxG2sUbQEFA4y36NAoRjuN+Z3PlY0znmmgr7ZSo=
+github.com/multiversx/mx-chain-core-go v1.2.4-0.20230517135533-2e54a17cd912/go.mod h1:jzYFSiYBuO0dGpGFXnZWSwcwcKP7Flyn/X41y4zIQrQ=
 github.com/multiversx/mx-chain-logger-go v1.0.11 h1:DFsHa+sc5fKwhDR50I8uBM99RTDTEW68ESyr5ALRDwE=
 github.com/multiversx/mx-chain-logger-go v1.0.11/go.mod h1:1srDkP0DQucWQ+rYfaq0BX2qLnULsUdRPADpYUTM6dA=
 github.com/multiversx/mx-chain-vm-common-go v1.4.0 h1:0i0cJZJOXGzqYzwtKFHSr2yGmnFAdizOuISK8HgsnYo=

--- a/integrationtests/accountsBalanceNftTransfer_test.go
+++ b/integrationtests/accountsBalanceNftTransfer_test.go
@@ -23,7 +23,6 @@ func createOutportBlockWithHeader(
 	header coreData.HeaderHandler,
 	pool *outport.TransactionPool,
 	coreAlteredAccounts map[string]*alteredAccount.AlteredAccount,
-	importDD bool,
 	numOfShards uint32,
 ) *outport.OutportBlockWithHeader {
 	return &outport.OutportBlockWithHeader{
@@ -34,7 +33,6 @@ func createOutportBlockWithHeader(
 			TransactionPool: pool,
 			AlteredAccounts: coreAlteredAccounts,
 			NumberOfShards:  numOfShards,
-			IsImportDB:      importDD,
 		},
 		Header: header,
 	}
@@ -91,7 +89,7 @@ func TestAccountBalanceNFTTransfer(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{fmt.Sprintf("%s-NFT-abcdef-718863", addr)}
@@ -152,7 +150,7 @@ func TestAccountBalanceNFTTransfer(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{fmt.Sprintf("%s-NFT-abcdef-718863", addr)}

--- a/integrationtests/accountsBalanceWithLowerTimestamp_test.go
+++ b/integrationtests/accountsBalanceWithLowerTimestamp_test.go
@@ -78,7 +78,7 @@ func TestIndexAccountsBalance(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{addr}
@@ -101,7 +101,7 @@ func TestIndexAccountsBalance(t *testing.T) {
 		ShardID:   2,
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{addr}
@@ -163,7 +163,7 @@ func TestIndexAccountsBalance(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{addr}
@@ -198,7 +198,7 @@ func TestIndexAccountsBalance(t *testing.T) {
 	}
 
 	pool.Transactions = make(map[string]*outport.TxInfo)
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{addr}

--- a/integrationtests/accountsESDTRollback_test.go
+++ b/integrationtests/accountsESDTRollback_test.go
@@ -80,7 +80,7 @@ func TestAccountsESDTDeleteOnRollback(t *testing.T) {
 		ShardID:   2,
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{fmt.Sprintf("%s-TOKEN-eeee-02", addr)}

--- a/integrationtests/accountsESDTWithTokenType_test.go
+++ b/integrationtests/accountsESDTWithTokenType_test.go
@@ -56,7 +56,7 @@ func TestIndexAccountESDTWithTokenType(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"SEMI-abcd"}
@@ -117,7 +117,7 @@ func TestIndexAccountESDTWithTokenType(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{fmt.Sprintf("%s-SEMI-abcd-02", address)}
@@ -189,7 +189,7 @@ func TestIndexAccountESDTWithTokenTypeShardFirstAndMetachainAfter(t *testing.T) 
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{fmt.Sprintf("%s-TTTT-abcd-02", address)}
@@ -228,7 +228,7 @@ func TestIndexAccountESDTWithTokenTypeShardFirstAndMetachainAfter(t *testing.T) 
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"TTTT-abcd"}

--- a/integrationtests/claimRewards_test.go
+++ b/integrationtests/claimRewards_test.go
@@ -121,7 +121,7 @@ func TestTransactionWithClaimRewardsGasRefund(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/createNFTWithTags_test.go
+++ b/integrationtests/createNFTWithTags_test.go
@@ -88,7 +88,7 @@ func TestCreateNFTWithTags(t *testing.T) {
 	}
 
 	body := &dataBlock.Body{}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{fmt.Sprintf("%s-DESK-abcd-01", address1)}
@@ -135,7 +135,7 @@ func TestCreateNFTWithTags(t *testing.T) {
 
 	coreAlteredAccounts[address1].Tokens[0].Nonce = 2
 	body = &dataBlock.Body{}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	genericResponse = &GenericResponse{}
@@ -183,7 +183,7 @@ func TestCreateNFTWithTags(t *testing.T) {
 	}
 
 	body = &dataBlock.Body{}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, coreAlteredAccounts, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = append(ids, "XFxcXFxcXFxcXFxcXFxcXFxcXA==", "JycnJw==", "PDw8Pj4+JiYmJiYmJiYmJiYmJiYm")

--- a/integrationtests/delegators_test.go
+++ b/integrationtests/delegators_test.go
@@ -59,7 +59,7 @@ func TestDelegateUnDelegateAndWithdraw(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"9v/pLAXxUZJ4Oy1U+x5al/Xg5sebh1dYCRTeZwg/u68="}
@@ -91,7 +91,7 @@ func TestDelegateUnDelegateAndWithdraw(t *testing.T) {
 	}
 
 	header.TimeStamp = 5050
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.DelegatorsIndex, true, genericResponse)
@@ -121,7 +121,7 @@ func TestDelegateUnDelegateAndWithdraw(t *testing.T) {
 	}
 
 	header.TimeStamp = 5060
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.DelegatorsIndex, true, genericResponse)
@@ -161,7 +161,7 @@ func TestDelegateUnDelegateAndWithdraw(t *testing.T) {
 	}
 
 	header.TimeStamp = 5070
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.DelegatorsIndex, true, genericResponse)

--- a/integrationtests/esdtTransfer_test.go
+++ b/integrationtests/esdtTransfer_test.go
@@ -102,7 +102,7 @@ func TestESDTTransferTooMuchGasProvided(t *testing.T) {
 			hex.EncodeToString(scrHash1): {SmartContractResult: scr1, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/issueTokenAndSetRoles_test.go
+++ b/integrationtests/issueTokenAndSetRoles_test.go
@@ -57,7 +57,7 @@ func TestIssueTokenAndSetRole(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"TOK-abcd"}
@@ -86,7 +86,7 @@ func TestIssueTokenAndSetRole(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"TOK-abcd"}
@@ -119,7 +119,7 @@ func TestIssueTokenAndSetRole(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"TOK-abcd"}
@@ -148,7 +148,7 @@ func TestIssueTokenAndSetRole(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"TOK-abcd"}
@@ -195,7 +195,7 @@ func TestIssueSetRolesEventAndAfterTokenIssue(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"TTT-abcd"}
@@ -223,7 +223,7 @@ func TestIssueSetRolesEventAndAfterTokenIssue(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"TTT-abcd"}

--- a/integrationtests/issueToken_test.go
+++ b/integrationtests/issueToken_test.go
@@ -51,7 +51,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"SSSS-abcd"}
@@ -84,7 +84,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TokensIndex, true, genericResponse)
@@ -115,7 +115,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TokensIndex, true, genericResponse)
@@ -142,7 +142,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	header.TimeStamp = 10000
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TokensIndex, true, genericResponse)

--- a/integrationtests/logsCrossShard_test.go
+++ b/integrationtests/logsCrossShard_test.go
@@ -55,7 +55,7 @@ func TestIndexLogSourceShardAndAfterDestinationAndAgainSource(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{logID}
@@ -96,7 +96,7 @@ func TestIndexLogSourceShardAndAfterDestinationAndAgainSource(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.LogsIndex, true, genericResponse)
@@ -129,7 +129,7 @@ func TestIndexLogSourceShardAndAfterDestinationAndAgainSource(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, map[string]*alteredAccount.AlteredAccount{}, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.LogsIndex, true, genericResponse)

--- a/integrationtests/multiTransferWithScCallAndErrorSignaledBySC_test.go
+++ b/integrationtests/multiTransferWithScCallAndErrorSignaledBySC_test.go
@@ -91,7 +91,7 @@ func TestMultiTransferCrossShardAndScCallErrorSignaledBySC(t *testing.T) {
 			hex.EncodeToString(scrHash1): {SmartContractResult: scr1, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 	ids := []string{hex.EncodeToString(txHash)}
 	genericResponse := &GenericResponse{}
@@ -159,7 +159,7 @@ func TestMultiTransferCrossShardAndScCallErrorSignaledBySC(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{hex.EncodeToString(txHash)}

--- a/integrationtests/nftIssueCreateBurn_test.go
+++ b/integrationtests/nftIssueCreateBurn_test.go
@@ -54,7 +54,7 @@ func TestIssueNFTCreateAndBurn(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"NON-abcd"}
@@ -99,7 +99,7 @@ func TestIssueNFTCreateAndBurn(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"NON-abcd-02"}
@@ -134,7 +134,7 @@ func TestIssueNFTCreateAndBurn(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"NON-abcd-02"}

--- a/integrationtests/nftTransferCrossShard_test.go
+++ b/integrationtests/nftTransferCrossShard_test.go
@@ -91,7 +91,7 @@ func TestNFTTransferCrossShardWithSCCall(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}
@@ -131,7 +131,7 @@ func TestNFTTransferCrossShardWithSCCall(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TransactionsIndex, true, genericResponse)
@@ -235,7 +235,7 @@ func TestNFTTransferCrossShard(t *testing.T) {
 			hex.EncodeToString(scrHash2): {SmartContractResult: scr2, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}
@@ -273,7 +273,7 @@ func TestNFTTransferCrossShard(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TransactionsIndex, true, genericResponse)
@@ -341,7 +341,7 @@ func TestNFTTransferCrossShardImportDBScenarioFirstIndexDestinationAfterSource(t
 
 	ids := []string{hex.EncodeToString(txHash)}
 	genericResponse := &GenericResponse{}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TransactionsIndex, true, genericResponse)
@@ -410,7 +410,7 @@ func TestNFTTransferCrossShardImportDBScenarioFirstIndexDestinationAfterSource(t
 			hex.EncodeToString(scrHash2): {SmartContractResult: scr2, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TransactionsIndex, true, genericResponse)

--- a/integrationtests/nftTransferCrossWithScCall_test.go
+++ b/integrationtests/nftTransferCrossWithScCall_test.go
@@ -87,7 +87,7 @@ func TestNFTTransferCrossShardWithScCall(t *testing.T) {
 			hex.EncodeToString(scrHash2): {SmartContractResult: scr2, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/relayedTx_test.go
+++ b/integrationtests/relayedTx_test.go
@@ -90,7 +90,7 @@ func TestRelayedTransactionGasUsedCrossShard(t *testing.T) {
 			hex.EncodeToString(scrHash1): {SmartContractResult: scr1, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}
@@ -132,7 +132,7 @@ func TestRelayedTransactionGasUsedCrossShard(t *testing.T) {
 		},
 	}
 
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(bodyDstShard, header, poolDstShard, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	err = esClient.DoMultiGet(ids, indexerdata.TransactionsIndex, true, genericResponse)
@@ -231,7 +231,7 @@ func TestRelayedTransactionIntraShard(t *testing.T) {
 			hex.EncodeToString(scrHash2): {SmartContractResult: scr2, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/scCallIntraShard_test.go
+++ b/integrationtests/scCallIntraShard_test.go
@@ -82,7 +82,7 @@ func TestTransactionWithSCCallFail(t *testing.T) {
 			}, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}
@@ -162,7 +162,7 @@ func TestTransactionWithScCallSuccess(t *testing.T) {
 			}, FeeInfo: &outport.FeeInfo{}},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/transactions_test.go
+++ b/integrationtests/transactions_test.go
@@ -63,7 +63,7 @@ func TestElasticIndexerSaveTransactions(t *testing.T) {
 			hex.EncodeToString(txHash): txInfo,
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{hex.EncodeToString(txHash)}

--- a/integrationtests/updateNFT_test.go
+++ b/integrationtests/updateNFT_test.go
@@ -59,7 +59,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids := []string{"NFT-abcd-0e"}
@@ -86,7 +86,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	// Add URIS 2 --- results should be the same
@@ -107,7 +107,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	// Update attributes 1
@@ -134,7 +134,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"NFT-abcd-0e"}
@@ -162,7 +162,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 
 	ids = []string{"NFT-abcd-0e"}
@@ -189,7 +189,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 	ids = []string{"NFT-abcd-0e"}
 	genericResponse = &GenericResponse{}
@@ -215,7 +215,7 @@ func TestNFTUpdateMetadata(t *testing.T) {
 			},
 		},
 	}
-	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, false, testNumOfShards))
+	err = esProc.SaveTransactions(createOutportBlockWithHeader(body, header, pool, nil, testNumOfShards))
 	require.Nil(t, err)
 	ids = []string{"NFT-abcd-0e"}
 	genericResponse = &GenericResponse{}

--- a/process/dataindexer/workItems/workItemBlock.go
+++ b/process/dataindexer/workItems/workItemBlock.go
@@ -42,13 +42,14 @@ func (wib *itemBlock) Save() error {
 	headerNonce := wib.outportBlockWithHeader.Header.GetNonce()
 	headerHash := wib.outportBlockWithHeader.BlockData.HeaderHash
 	shardID := wib.outportBlockWithHeader.Header.GetShardID()
-	startTime := time.Now()
-	defer log.Debug("wib.SaveBlockData",
-		"duration", time.Since(startTime),
-		"shardID", shardID,
-		"nonce", headerNonce,
-		"hash", headerHash,
-	)
+	defer func(startTime time.Time, headerHash []byte, headerNonce uint64, shardID uint32) {
+		log.Debug("wib.SaveBlockData",
+			"duration", time.Since(startTime),
+			"shardID", shardID,
+			"nonce", headerNonce,
+			"hash", headerHash,
+		)
+	}(time.Now(), headerHash, headerNonce, shardID)
 
 	log.Debug("indexer: starting indexing block",
 		"hash", wib.outportBlockWithHeader.BlockData.HeaderHash,

--- a/process/dataindexer/workItems/workItemBlock.go
+++ b/process/dataindexer/workItems/workItemBlock.go
@@ -42,14 +42,13 @@ func (wib *itemBlock) Save() error {
 	headerNonce := wib.outportBlockWithHeader.Header.GetNonce()
 	headerHash := wib.outportBlockWithHeader.BlockData.HeaderHash
 	shardID := wib.outportBlockWithHeader.Header.GetShardID()
-	defer func(startTime time.Time, headerHash []byte, headerNonce uint64, shardID uint32) {
-		log.Debug("wib.SaveBlockData",
-			"duration", time.Since(startTime),
-			"shardID", shardID,
-			"nonce", headerNonce,
-			"hash", headerHash,
-		)
-	}(time.Now(), headerHash, headerNonce, shardID)
+	startTime := time.Now()
+	defer log.Debug("wib.SaveBlockData",
+		"duration", time.Since(startTime),
+		"shardID", shardID,
+		"nonce", headerNonce,
+		"hash", headerHash,
+	)
 
 	log.Debug("indexer: starting indexing block",
 		"hash", wib.outportBlockWithHeader.BlockData.HeaderHash,

--- a/process/elasticproc/factory/elasticProcessorFactory.go
+++ b/process/elasticproc/factory/elasticProcessorFactory.go
@@ -29,6 +29,7 @@ type ArgElasticProcessorFactory struct {
 	Denomination             int
 	BulkRequestMaxSize       int
 	UseKibana                bool
+	ImportDB                 bool
 }
 
 // CreateElasticProcessor will create a new instance of ElasticProcessor
@@ -118,6 +119,7 @@ func CreateElasticProcessor(arguments ArgElasticProcessorFactory) (dataindexer.E
 		IndexTemplates:     indexTemplates,
 		IndexPolicies:      indexPolicies,
 		OperationsProc:     operationsProc,
+		ImportDB:           arguments.ImportDB,
 	}
 
 	return elasticproc.NewElasticProcessor(args)

--- a/process/factory/indexerFactory.go
+++ b/process/factory/indexerFactory.go
@@ -26,6 +26,7 @@ var log = logger.GetOrCreate("indexer/factory")
 type ArgsIndexerFactory struct {
 	Enabled                  bool
 	UseKibana                bool
+	ImportDB                 bool
 	IndexerCacheSize         int
 	Denomination             int
 	BulkRequestMaxSize       int
@@ -105,6 +106,7 @@ func createElasticProcessor(args ArgsIndexerFactory) (dataindexer.ElasticProcess
 		Denomination:             args.Denomination,
 		EnabledIndexes:           args.EnabledIndexes,
 		BulkRequestMaxSize:       args.BulkRequestMaxSize,
+		ImportDB:                 args.ImportDB,
 	}
 
 	return factory.CreateElasticProcessor(argsElasticProcFac)

--- a/scripts/observers/.env
+++ b/scripts/observers/.env
@@ -7,8 +7,8 @@ NODE_GO_BRANCH="integrate-new-ws-client-server"
 WORKING_DIRECTORY="IndexerObservers"
 OBSERVER_DIR_PREFIX="observer_shard_"
 
-# marshaller types: `json` or `gogo proto`
-WS_MARSHALLER_TYPE="json"
+# marshaller types: `json` or `gogo protobuf`
+WS_MARSHALLER_TYPE="gogo protobuf"
 
 NUM_OF_SHARDS=3 #MAX 3
 


### PR DESCRIPTION
This pull request addresses multiple aspects to enhance the functionality of the system:

- Resolved a minor issue that was causing the data indexer to fail initialization, ensuring smooth execution.
- Made necessary improvements to certain log statements for better clarity and understanding.
- Introduced the `import-db` flag as a replacement for the removed boolean parameter in the `OutportBlock` structure. This new flag enables starting the indexer in the import database mode.