### PR TITLE
Refactor the indexing part of the `mini-blocks`

### DIFF
--- a/client/elasticClient.go
+++ b/client/elasticClient.go
@@ -93,16 +93,6 @@ func (ec *elasticClient) CheckAndCreateAlias(alias string, indexName string) err
 	return ec.createAlias(alias, indexName)
 }
 
-// DoRequest will do a request to elastic server
-func (ec *elasticClient) DoRequest(ctx context.Context, req *esapi.IndexRequest) error {
-	res, err := req.Do(ctx, ec.client)
-	if err != nil {
-		return err
-	}
-
-	return parseResponse(res, nil, elasticDefaultErrorResponseHandler)
-}
-
 // DoBulkRequest will do a bulk of request to elastic server
 func (ec *elasticClient) DoBulkRequest(ctx context.Context, buff *bytes.Buffer, index string) error {
 	reader := bytes.NewReader(buff.Bytes())

--- a/integrationtests/miniblocks_test.go
+++ b/integrationtests/miniblocks_test.go
@@ -1,0 +1,122 @@
+package integrationtests
+
+import (
+	"context"
+	"testing"
+
+	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/marshal"
+	indexerdata "github.com/multiversx/mx-chain-es-indexer-go/process/dataindexer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexMiniBlocksOnSourceAndDestination(t *testing.T) {
+	setLogLevelDebug()
+
+	esClient, err := createESClient(esURL)
+	require.Nil(t, err)
+	esProc, err := CreateElasticProcessor(esClient)
+	require.Nil(t, err)
+
+	// index on the source shard
+	header := &dataBlock.Header{
+		ShardID:   1,
+		TimeStamp: 1234,
+	}
+	miniBlocks := []*dataBlock.MiniBlock{
+		{
+			SenderShardID:   1,
+			ReceiverShardID: 2,
+		},
+	}
+	err = esProc.SaveMiniblocks(header, miniBlocks)
+	require.Nil(t, err)
+	mbHash := "11a1bb4065e16a2e93b2b5ac5957b7b69f1cfba7579b170b24f30dab2d3162e0"
+	ids := []string{mbHash}
+	genericResponse := &GenericResponse{}
+	err = esClient.DoMultiGet(context.Background(), ids, indexerdata.MiniblocksIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/miniblocks/cross-miniblock-on-source.json"), string(genericResponse.Docs[0].Source))
+
+	// index on the destination shard
+	mbhr := &dataBlock.MiniBlockHeaderReserved{
+		ExecutionType: dataBlock.ProcessingType(1),
+	}
+
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	mbhrBytes, _ := marshaller.Marshal(mbhr)
+	header = &dataBlock.Header{
+		ShardID:   2,
+		TimeStamp: 1234,
+		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
+			{
+				Reserved: mbhrBytes,
+			},
+		},
+	}
+
+	err = esProc.SaveMiniblocks(header, miniBlocks)
+	require.Nil(t, err)
+
+	err = esClient.DoMultiGet(context.Background(), ids, indexerdata.MiniblocksIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/miniblocks/cross-miniblock-on-destination.json"), string(genericResponse.Docs[0].Source))
+}
+
+func TestIndexMiniBlockFirstOnDestinationAndAfterSource(t *testing.T) {
+	setLogLevelDebug()
+
+	esClient, err := createESClient(esURL)
+	require.Nil(t, err)
+	esProc, err := CreateElasticProcessor(esClient)
+	require.Nil(t, err)
+
+	// index on destination
+	mbhr := &dataBlock.MiniBlockHeaderReserved{
+		ExecutionType: dataBlock.ProcessingType(2),
+	}
+
+	marshaller := &marshal.GogoProtoMarshalizer{}
+	mbhrBytes, _ := marshaller.Marshal(mbhr)
+	header := &dataBlock.Header{
+		ShardID:   0,
+		TimeStamp: 54321,
+		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
+			{
+				Reserved: mbhrBytes,
+			},
+		},
+	}
+	miniBlocks := []*dataBlock.MiniBlock{
+		{
+			SenderShardID:   2,
+			ReceiverShardID: 0,
+		},
+	}
+
+	err = esProc.SaveMiniblocks(header, miniBlocks)
+	require.Nil(t, err)
+	genericResponse := &GenericResponse{}
+
+	ids := []string{"2f3ee0ff3b6426916df3b123a10f425b7e2027e2ae8d231229d27b12aa522ade"}
+	err = esClient.DoMultiGet(context.Background(), ids, indexerdata.MiniblocksIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/miniblocks/cross-miniblock-on-destination-first.json"), string(genericResponse.Docs[0].Source))
+
+	// index on source
+	mbhr = &dataBlock.MiniBlockHeaderReserved{
+		ExecutionType: dataBlock.ProcessingType(0),
+	}
+	mbhrBytes, _ = marshaller.Marshal(mbhr)
+	header.ShardID = 2
+	header.MiniBlockHeaders = []dataBlock.MiniBlockHeader{
+		{
+			Reserved: mbhrBytes,
+		},
+	}
+	err = esProc.SaveMiniblocks(header, miniBlocks)
+	require.Nil(t, err)
+	err = esClient.DoMultiGet(context.Background(), ids, indexerdata.MiniblocksIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/miniblocks/cross-miniblock-on-source-second.json"), string(genericResponse.Docs[0].Source))
+}

--- a/integrationtests/miniblocks_test.go
+++ b/integrationtests/miniblocks_test.go
@@ -1,3 +1,5 @@
+//go:build integrationtests
+
 package integrationtests
 
 import (

--- a/integrationtests/testdata/miniblocks/cross-miniblock-on-destination-first.json
+++ b/integrationtests/testdata/miniblocks/cross-miniblock-on-destination-first.json
@@ -1,0 +1,8 @@
+{
+  "procTypeD": "Processed",
+  "receiverShard": 0,
+  "senderShard": 2,
+  "receiverBlockHash": "b36435faaa72390772da84f418348ce0d477c74432579519bf0ffea1dc4c36e9",
+  "type": "TxBlock",
+  "timestamp": 54321
+}

--- a/integrationtests/testdata/miniblocks/cross-miniblock-on-destination.json
+++ b/integrationtests/testdata/miniblocks/cross-miniblock-on-destination.json
@@ -1,0 +1,10 @@
+{
+  "procTypeS": "Normal",
+  "senderBlockHash": "3fede8a9a3c4f2ba6d7e6e01541813606cd61c4d3af2940f8e089827b5d94e50",
+  "receiverShard": 2,
+  "senderShard": 1,
+  "type": "TxBlock",
+  "timestamp": 1234,
+  "receiverBlockHash": "d7f1e8003a45c7adbd87bbbb269cb4af3d1f4aedd0c214973bfc096dd0f3b65e",
+  "procTypeD": "Scheduled"
+}

--- a/integrationtests/testdata/miniblocks/cross-miniblock-on-source-second.json
+++ b/integrationtests/testdata/miniblocks/cross-miniblock-on-source-second.json
@@ -1,0 +1,10 @@
+{
+  "procTypeD": "Processed",
+  "receiverShard": 0,
+  "senderShard": 2,
+  "receiverBlockHash": "b36435faaa72390772da84f418348ce0d477c74432579519bf0ffea1dc4c36e9",
+  "type": "TxBlock",
+  "timestamp": 54321,
+  "senderBlockHash": "b601381e1f41df2aa3da9f2b8eb169f14c86418229e30fc65f9e6b37b7f0d902",
+  "procTypeS": "Normal"
+}

--- a/integrationtests/testdata/miniblocks/cross-miniblock-on-source.json
+++ b/integrationtests/testdata/miniblocks/cross-miniblock-on-source.json
@@ -1,0 +1,8 @@
+{
+  "procTypeS": "Normal",
+  "senderBlockHash": "3fede8a9a3c4f2ba6d7e6e01541813606cd61c4d3af2940f8e089827b5d94e50",
+  "receiverShard": 2,
+  "senderShard": 1,
+  "type": "TxBlock",
+  "timestamp": 1234
+}

--- a/integrationtests/utils.go
+++ b/integrationtests/utils.go
@@ -58,7 +58,7 @@ func CreateElasticProcessor(
 		DBClient:                 esClient,
 		EnabledIndexes: []string{dataindexer.TransactionsIndex, dataindexer.LogsIndex, dataindexer.AccountsESDTIndex, dataindexer.ScResultsIndex,
 			dataindexer.ReceiptsIndex, dataindexer.BlockIndex, dataindexer.AccountsIndex, dataindexer.TokensIndex, dataindexer.TagsIndex,
-			dataindexer.OperationsIndex, dataindexer.DelegatorsIndex, dataindexer.ESDTsIndex, dataindexer.SCDeploysIndex},
+			dataindexer.OperationsIndex, dataindexer.DelegatorsIndex, dataindexer.ESDTsIndex, dataindexer.SCDeploysIndex, dataindexer.MiniblocksIndex},
 		Denomination: 18,
 	}
 

--- a/mock/databaseWriterStub.go
+++ b/mock/databaseWriterStub.go
@@ -3,13 +3,10 @@ package mock
 import (
 	"bytes"
 	"context"
-
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 )
 
 // DatabaseWriterStub -
 type DatabaseWriterStub struct {
-	DoRequestCalled           func(req *esapi.IndexRequest) error
 	DoBulkRequestCalled       func(buff *bytes.Buffer, index string) error
 	DoQueryRemoveCalled       func(index string, body *bytes.Buffer) error
 	DoMultiGetCalled          func(ids []string, index string, withSource bool, response interface{}) error
@@ -31,14 +28,6 @@ func (dwm *DatabaseWriterStub) DoCountRequest(_ context.Context, _ string, _ []b
 func (dwm *DatabaseWriterStub) DoScrollRequest(_ context.Context, index string, body []byte, withSource bool, handlerFunc func(responseBytes []byte) error) error {
 	if dwm.DoScrollRequestCalled != nil {
 		return dwm.DoScrollRequestCalled(index, body, withSource, handlerFunc)
-	}
-	return nil
-}
-
-// DoRequest -
-func (dwm *DatabaseWriterStub) DoRequest(_ context.Context, req *esapi.IndexRequest) error {
-	if dwm.DoRequestCalled != nil {
-		return dwm.DoRequestCalled(req)
 	}
 	return nil
 }

--- a/process/elasticproc/interface.go
+++ b/process/elasticproc/interface.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 	coreData "github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/alteredAccount"
 	"github.com/multiversx/mx-chain-core-go/data/block"
@@ -15,7 +14,6 @@ import (
 
 // DatabaseClientHandler defines the actions that a component that handles requests should do
 type DatabaseClientHandler interface {
-	DoRequest(ctx context.Context, req *esapi.IndexRequest) error
 	DoBulkRequest(ctx context.Context, buff *bytes.Buffer, index string) error
 	DoQueryRemove(ctx context.Context, index string, buff *bytes.Buffer) error
 	DoMultiGet(ctx context.Context, ids []string, index string, withSource bool, res interface{}) error
@@ -77,7 +75,7 @@ type DBMiniblocksHandler interface {
 	PrepareDBMiniblocks(header coreData.HeaderHandler, miniBlocks []*block.MiniBlock) []*data.Miniblock
 	GetMiniblocksHashesHexEncoded(header coreData.HeaderHandler, body *block.Body) []string
 
-	SerializeBulkMiniBlocks(bulkMbs []*data.Miniblock, mbsInDB map[string]bool, buffSlice *data.BufferSlice, index string, shardID uint32)
+	SerializeBulkMiniBlocks(bulkMbs []*data.Miniblock, buffSlice *data.BufferSlice, index string, shardID uint32)
 }
 
 // DBStatisticsHandler defines the actions that a database statistics handler should do

--- a/process/elasticproc/miniblocks/serialize_test.go
+++ b/process/elasticproc/miniblocks/serialize_test.go
@@ -23,9 +23,9 @@ func TestMiniblocksProcessor_SerializeBulkMiniBlocks(t *testing.T) {
 	mp.SerializeBulkMiniBlocks(miniblocks, buffSlice, "miniblocks", 0)
 
 	expectedBuff := `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"type":"","timestamp":0}, "osnp": true }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"type":"","timestamp":0}, "npos": true }},"upsert": {}}
 { "update" : {"_index":"miniblocks", "_id" : "h2" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":2,"type":"","timestamp":0}, "osnp": true }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":2,"type":"","timestamp":0}, "npos": true }},"upsert": {}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
@@ -44,9 +44,9 @@ func TestMiniblocksProcessor_SerializeBulkMiniBlocksInDB(t *testing.T) {
 	mp.SerializeBulkMiniBlocks(miniblocks, buffSlice, "miniblocks", 0)
 
 	expectedBuff := `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"type":"","timestamp":0}, "osnp": true }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"type":"","timestamp":0}, "npos": true }},"upsert": {}}
 { "update" : {"_index":"miniblocks", "_id" : "h2" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":2,"type":"","timestamp":0}, "osnp": true }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":2,"type":"","timestamp":0}, "npos": true }},"upsert": {}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
@@ -62,7 +62,7 @@ func TestSerializeMiniblock_CrossShardNormal(t *testing.T) {
 	mp.SerializeBulkMiniBlocks(miniblocks, buffSlice, "miniblocks", 1)
 
 	expectedBuff := `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"receiverBlockHash":"receiverBlock","type":"","timestamp":0}, "osnp": false }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":0,"receiverShard":1,"receiverBlockHash":"receiverBlock","type":"","timestamp":0}, "npos": false }},"upsert": {}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
@@ -79,7 +79,7 @@ func TestSerializeMiniblock_IntraShardScheduled(t *testing.T) {
 	mp.SerializeBulkMiniBlocks(miniblocks, buffSlice, "miniblocks", 1)
 
 	expectedBuff := `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":1,"receiverShard":1,"senderBlockHash":"senderBlock","type":"","procTypeS":"Scheduled","timestamp":0}, "osnp": true }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":1,"receiverShard":1,"senderBlockHash":"senderBlock","type":"","procTypeS":"Scheduled","timestamp":0}, "npos": true }},"upsert": {}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 
@@ -92,7 +92,7 @@ func TestSerializeMiniblock_IntraShardScheduled(t *testing.T) {
 	mp.SerializeBulkMiniBlocks(miniblocks, buffSlice, "miniblocks", 1)
 
 	expectedBuff = `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
-{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.osnp) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":1,"receiverShard":1,"receiverBlockHash":"receiverBlock","type":"","procTypeD":"Processed","timestamp":0}, "osnp": false }},"upsert": {}}
+{"scripted_upsert": true, "script": {"source": "if ('create' == ctx.op) {ctx._source = params.mb} else {if (params.npos) {ctx._source.senderBlockHash = params.mb.senderBlockHash;ctx._source.procTypeS = params.mb.procTypeS;} else {ctx._source.receiverBlockHash = params.mb.receiverBlockHash;ctx._source.procTypeD = params.mb.procTypeD;}}","lang": "painless","params": { "mb": {"senderShard":1,"receiverShard":1,"receiverBlockHash":"receiverBlock","type":"","procTypeD":"Processed","timestamp":0}, "npos": false }},"upsert": {}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }


### PR DESCRIPTION
- Refactored the indexing part of the `mini-blocks`. 
- The old implementation had to do GET requests in order to know how to index the `mini-blocks`, this behavior generate some problems because there are conflicts. (the indexer had to do retries)  In order to fix the problem now mini-blocks are indexed with a `scripted_upsert` operation that will fix all these problems.