### PR TITLE
Integrate latest version of `mx-chain-communication-go`

### DIFF
--- a/data/logs.go
+++ b/data/logs.go
@@ -18,11 +18,12 @@ type Logs struct {
 
 // Event holds all the fields needed for an event structure
 type Event struct {
-	Address    string   `json:"address"`
-	Identifier string   `json:"identifier"`
-	Topics     [][]byte `json:"topics"`
-	Data       []byte   `json:"data"`
-	Order      int      `json:"order"`
+	Address        string   `json:"address"`
+	Identifier     string   `json:"identifier"`
+	Topics         [][]byte `json:"topics"`
+	Data           []byte   `json:"data"`
+	AdditionalData [][]byte `json:"additionalData,omitempty"`
+	Order          int      `json:"order"`
 }
 
 // PreparedLogsResults is the DTO that holds all the results after processing

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.12.0
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/multiversx/mx-chain-communication-go v1.0.6
-	github.com/multiversx/mx-chain-core-go v1.2.15
+	github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631
+	github.com/multiversx/mx-chain-core-go v1.2.16
 	github.com/multiversx/mx-chain-logger-go v1.0.13
 	github.com/multiversx/mx-chain-vm-common-go v1.5.2
 	github.com/prometheus/client_model v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.12.0
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631
+	github.com/multiversx/mx-chain-communication-go v1.0.7
 	github.com/multiversx/mx-chain-core-go v1.2.16
 	github.com/multiversx/mx-chain-logger-go v1.0.13
 	github.com/multiversx/mx-chain-vm-common-go v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631 h1:E3k9OgTMWWTm/Aytj4ON3Rbg8Bf/S9ZKtCk5EWXQIC4=
-github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
+github.com/multiversx/mx-chain-communication-go v1.0.7 h1:7qeDBcqmGYYhSqFcpwv0qKkR3ahOfIMbRwXYEnOt/do=
+github.com/multiversx/mx-chain-communication-go v1.0.7/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
 github.com/multiversx/mx-chain-core-go v1.2.16 h1:m0hUNmZQjGJxKDLQOHoM9jSaeDfVTbyd+mqiS8+NckE=
 github.com/multiversx/mx-chain-core-go v1.2.16/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=

--- a/go.sum
+++ b/go.sum
@@ -247,10 +247,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiversx/mx-chain-communication-go v1.0.6 h1:f2bizRoVuJXBWc32px7pCuzMx4Pgi2tKhUt8BkFV1Fg=
-github.com/multiversx/mx-chain-communication-go v1.0.6/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
-github.com/multiversx/mx-chain-core-go v1.2.15 h1:2qbcGP9yHi9CFeLF9xTDnDPJjvafvTmwEkitfI0wWME=
-github.com/multiversx/mx-chain-core-go v1.2.15/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
+github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631 h1:E3k9OgTMWWTm/Aytj4ON3Rbg8Bf/S9ZKtCk5EWXQIC4=
+github.com/multiversx/mx-chain-communication-go v1.0.7-0.20230920140934-77ca04b5a631/go.mod h1:+oaUowpq+SqrEmAsMPGwhz44g7L81loWb6AiNQU9Ms4=
+github.com/multiversx/mx-chain-core-go v1.2.16 h1:m0hUNmZQjGJxKDLQOHoM9jSaeDfVTbyd+mqiS8+NckE=
+github.com/multiversx/mx-chain-core-go v1.2.16/go.mod h1:BILOGHUOIG5dNNX8cgkzCNfDaVtoYrJRYcPnpxRMH84=
 github.com/multiversx/mx-chain-crypto-go v1.2.8 h1:wOgVlUaO5X4L8iEbFjcQcL8SZvv6WZ7LqH73BiRPhxU=
 github.com/multiversx/mx-chain-logger-go v1.0.13 h1:eru/TETo0MkO4ZTnXsQDKf4PBRpAXmqjT02klNT/JnY=
 github.com/multiversx/mx-chain-logger-go v1.0.13/go.mod h1:MZJhTAtZTJxT+yK2EHc4ZW3YOHUc1UdjCD0iahRNBZk=

--- a/process/elasticproc/logsevents/logsAndEventsProcessor_test.go
+++ b/process/elasticproc/logsevents/logsAndEventsProcessor_test.go
@@ -216,9 +216,10 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 				Address: []byte("address"),
 				Events: []*transaction.Event{
 					{
-						Address:    []byte("addr"),
-						Identifier: []byte(core.BuiltInFunctionESDTNFTTransfer),
-						Topics:     [][]byte{[]byte("my-token"), big.NewInt(0).SetUint64(1).Bytes(), []byte("receiver")},
+						Address:        []byte("addr"),
+						Identifier:     []byte(core.BuiltInFunctionESDTNFTTransfer),
+						Topics:         [][]byte{[]byte("my-token"), big.NewInt(0).SetUint64(1).Bytes(), []byte("receiver")},
+						AdditionalData: [][]byte{[]byte("something")},
 					},
 				},
 			},
@@ -243,9 +244,10 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 		Timestamp:      time.Duration(1234),
 		Events: []*data.Event{
 			{
-				Address:    "61646472",
-				Identifier: core.BuiltInFunctionESDTNFTTransfer,
-				Topics:     [][]byte{[]byte("my-token"), big.NewInt(0).SetUint64(1).Bytes(), []byte("receiver")},
+				Address:        "61646472",
+				Identifier:     core.BuiltInFunctionESDTNFTTransfer,
+				Topics:         [][]byte{[]byte("my-token"), big.NewInt(0).SetUint64(1).Bytes(), []byte("receiver")},
+				AdditionalData: [][]byte{[]byte("something")},
 			},
 		},
 	}, logsDB[0])

--- a/process/wsindexer/indexer.go
+++ b/process/wsindexer/indexer.go
@@ -70,7 +70,11 @@ func (i *indexer) initActionsMap() {
 }
 
 // ProcessPayload will proces the provided payload based on the topic
-func (i *indexer) ProcessPayload(payload []byte, topic string) error {
+func (i *indexer) ProcessPayload(payload []byte, topic string, version uint32) error {
+	if version != 1 {
+		log.Warn("received a payload with a different version", "version", version)
+	}
+
 	payloadTypeAction, ok := i.actions[topic]
 	if !ok {
 		log.Warn("invalid payload type", "topic", topic)


### PR DESCRIPTION
- Integrated the latest version of the `mx-chain-communication-go`: https://github.com/multiversx/mx-chain-communication-go/pull/38

- Extend `logs` index with `AdditionalData` field
- Latest version of the `mx-chain-core-go` module