### PR TITLE
Extend `miniblocks` and `operations` index

### DIFF
--- a/cmd/elasticindexer/main.go
+++ b/cmd/elasticindexer/main.go
@@ -43,7 +43,7 @@ VERSION:
 // Usage examples:
 // linux/mac:
 //
-//	go build -v -ldflags="-X main.appVersion=$(git describe --tags --long --dirty)"
+//	go build -v -ldflags="-X main.version=$(git describe --tags --long --dirty)"
 //
 // windows:
 //

--- a/data/block.go
+++ b/data/block.go
@@ -102,6 +102,8 @@ type Miniblock struct {
 	Hash                        string        `json:"hash,omitempty"`
 	SenderShardID               uint32        `json:"senderShard"`
 	ReceiverShardID             uint32        `json:"receiverShard"`
+	SenderBlockNonce            uint64        `json:"senderBlockNonce,omitempty"`
+	ReceiverBlockNonce          uint64        `json:"receiverBlockNonce,omitempty"`
 	SenderBlockHash             string        `json:"senderBlockHash,omitempty"`
 	ReceiverBlockHash           string        `json:"receiverBlockHash,omitempty"`
 	Type                        string        `json:"type"`

--- a/process/elasticproc/miniblocks/miniblocksProcessor.go
+++ b/process/elasticproc/miniblocks/miniblocksProcessor.go
@@ -101,6 +101,7 @@ func (mp *miniblocksProcessor) prepareMiniblockForDB(
 
 	processingType, _ := mp.computeProcessingTypeAndConstructionState(mbIndex, header)
 	dbMiniblock.ProcessingTypeOnDestination = processingType
+	dbMiniblock.ReceiverBlockNonce = header.GetNonce()
 	dbMiniblock.ReceiverBlockHash = encodedHeaderHash
 
 	return dbMiniblock, nil
@@ -114,7 +115,7 @@ func (mp *miniblocksProcessor) setFieldsMBIntraShardAndCrossFromMe(
 	isIntraShard bool,
 ) {
 	processingType, constructionState := mp.computeProcessingTypeAndConstructionState(mbIndex, header)
-
+	dbMiniblock.SenderBlockNonce = header.GetNonce()
 	dbMiniblock.ProcessingTypeOnSource = processingType
 	switch {
 	case constructionState == int32(block.Final) && processingType == block.Normal.String():
@@ -122,6 +123,7 @@ func (mp *miniblocksProcessor) setFieldsMBIntraShardAndCrossFromMe(
 		dbMiniblock.ProcessingTypeOnSource = processingType
 		if isIntraShard {
 			dbMiniblock.ReceiverBlockHash = headerHash
+			dbMiniblock.ReceiverBlockNonce = header.GetNonce()
 			dbMiniblock.ProcessingTypeOnDestination = processingType
 		}
 	case constructionState == int32(block.Proposed) && processingType == block.Scheduled.String():
@@ -129,6 +131,7 @@ func (mp *miniblocksProcessor) setFieldsMBIntraShardAndCrossFromMe(
 		dbMiniblock.ProcessingTypeOnSource = processingType
 	case constructionState == int32(block.Final) && processingType == block.Processed.String():
 		dbMiniblock.ReceiverBlockHash = headerHash
+		dbMiniblock.ReceiverBlockNonce = header.GetNonce()
 		dbMiniblock.ProcessingTypeOnDestination = processingType
 	}
 }

--- a/process/elasticproc/miniblocks/miniblocksProcessor_test.go
+++ b/process/elasticproc/miniblocks/miniblocksProcessor_test.go
@@ -82,6 +82,7 @@ func TestMiniblocksProcessor_PrepareScheduledMB(t *testing.T) {
 	mbhrBytes, _ := marshalizer.Marshal(mbhr)
 
 	header := &dataBlock.Header{
+		Nonce: 100,
 		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
 			{
 				Reserved: []byte{0},
@@ -114,11 +115,13 @@ func TestMiniblocksProcessor_PrepareScheduledMB(t *testing.T) {
 		Hash:                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		SenderShardID:               0,
 		ReceiverShardID:             0,
-		SenderBlockHash:             "84b80cbf612d067201b5260b4c6f90fa7b5c11e898fa9c1c65f4c75e61e41619",
-		ReceiverBlockHash:           "84b80cbf612d067201b5260b4c6f90fa7b5c11e898fa9c1c65f4c75e61e41619",
+		SenderBlockHash:             "3e8098a9a58ec272b1a400d155b04d9e9488539ff93b1f746b410c3e07e1c6a4",
+		ReceiverBlockHash:           "3e8098a9a58ec272b1a400d155b04d9e9488539ff93b1f746b410c3e07e1c6a4",
 		ProcessingTypeOnSource:      dataBlock.Normal.String(),
 		ProcessingTypeOnDestination: dataBlock.Normal.String(),
 		Type:                        dataBlock.TxBlock.String(),
+		SenderBlockNonce:            100,
+		ReceiverBlockNonce:          100,
 	}, miniblocks[2])
 }
 

--- a/process/elasticproc/miniblocks/serialize.go
+++ b/process/elasticproc/miniblocks/serialize.go
@@ -50,9 +50,11 @@ func (mp *miniblocksProcessor) prepareMiniblockData(miniblockDB *data.Miniblock,
 	} else {
 		if (params.npos) {
 			ctx._source.senderBlockHash = params.mb.senderBlockHash;
+			ctx._source.senderBlockNonce = params.mb.senderBlockNonce;
 			ctx._source.procTypeS = params.mb.procTypeS;
 		} else {
 			ctx._source.receiverBlockHash = params.mb.receiverBlockHash;
+			ctx._source.receiverBlockNonce = params.mb.receiverBlockNonce;
 			ctx._source.procTypeD = params.mb.procTypeD;
 		}
 	}


### PR DESCRIPTION
- Extended the `miniblocks` index with extra fields: `senderBlockNonce`, `receiverBlockNonce`