### PR TITLE
Ignore receipts minbiblocks

### DIFF
--- a/process/elasticproc/block/blockProcessor.go
+++ b/process/elasticproc/block/blockProcessor.go
@@ -271,7 +271,7 @@ func appendBlockDetailsFromHeaders(block *data.Block, header coreData.HeaderHand
 
 func appendBlockDetailsFromIntraShardMbs(block *data.Block, intraShardMbs []*block.MiniBlock, pool *outport.TransactionPool, offset int) {
 	for idx, intraMB := range intraShardMbs {
-		if intraMB.Type == nodeBlock.PeerBlock {
+		if intraMB.Type == nodeBlock.PeerBlock || intraMB.Type == nodeBlock.ReceiptBlock {
 			continue
 		}
 


### PR DESCRIPTION
-Bug fix: fixed the bug with a lot of `WARN` messages ( `WARN [2024-05-09 16:00:09.405]   blockProcessor.extractExecutionOrderIntraShardMBUnsigned cannot find tx in pool txHash = 00316c3486a2150a3f39b16316c6642eecba7b7c9ce586317a23a8548e0eb944 `) 
This message appears because the indexer cannot find the receipt hash in the pool

- The receipts `miniblocks` should be ignored