### PR TITLE
Fixes refund index in case of rollback and scheduled execution

### DIFF
--- a/client/data.go
+++ b/client/data.go
@@ -28,8 +28,10 @@ type Item struct {
 		Type   string `json:"type"`
 		Reason string `json:"reason"`
 		Cause  struct {
-			Type   string `json:"type"`
-			Reason string `json:"reason"`
+			Type        string   `json:"type"`
+			Reason      string   `json:"reason"`
+			ScriptStack []string `json:"script_stack"`
+			Script      string   `json:"script"`
 		} `json:"caused_by"`
 	} `json:"error"`
 }

--- a/client/elasticClientCommon.go
+++ b/client/elasticClientCommon.go
@@ -134,8 +134,8 @@ func extractErrorFromBulkBodyResponseBytes(bodyBytes []byte) error {
 		}
 
 		count++
-		errorsString += fmt.Sprintf(`{ "index": "%s", "id": "%s", "statusCode": %d, "errorType": "%s", "reason": "%s", "causedBy": { "type": "%s", "reason": "%s" }}\n`,
-			selectedItem.Index, selectedItem.ID, selectedItem.Status, selectedItem.Error.Type, selectedItem.Error.Reason, selectedItem.Error.Cause.Type, selectedItem.Error.Cause.Reason)
+		errorsString += fmt.Sprintf(`{ "index": "%s", "id": "%s", "statusCode": %d, "errorType": "%s", "reason": "%s", "causedBy": { "type": "%s", "reason": "%s", "script_stack":"%s", "script":"%s" }}\n`,
+			selectedItem.Index, selectedItem.ID, selectedItem.Status, selectedItem.Error.Type, selectedItem.Error.Reason, selectedItem.Error.Cause.Type, selectedItem.Error.Cause.Reason, selectedItem.Error.Cause.ScriptStack, selectedItem.Error.Cause.Script)
 
 		if count == numOfErrorsToExtractBulkResponse {
 			break

--- a/process/elasticproc/transactions/serialize.go
+++ b/process/elasticproc/transactions/serialize.go
@@ -58,6 +58,11 @@ func (tdp *txsDatabaseProcessor) SerializeTransactionsFeeData(txHashRefund map[s
  			if ('create' == ctx.op) {
  				ctx.op = 'noop'
  			} else {
+				boolean ok1 = ((ctx._source.containsKey('initialPaidFee')) && (ctx._source.initialPaidFee != null) && (!ctx._source.initialPaidFee.isEmpty()));
+				boolean ok2 = ((ctx._source.containsKey('fee')) && (ctx._source.fee != null) && (!ctx._source.fee.isEmpty()));
+				if (!ok1 || !ok2) {
+					return
+				}
  				BigInteger feeFromSource;
 				if ((ctx._source.containsKey('hadRefund')) && (ctx._source.hadRefund)) {
 					feeFromSource = new BigInteger(ctx._source.fee);

--- a/process/elasticproc/transactions/transactionsProcessor.go
+++ b/process/elasticproc/transactions/transactionsProcessor.go
@@ -157,7 +157,11 @@ func (tdp *txsDatabaseProcessor) GetHexEncodedHashesForRemove(header coreData.He
 	selfShardID := header.GetShardID()
 	encodedTxsHashes := make([]string, 0)
 	encodedScrsHashes := make([]string, 0)
-	for _, miniblock := range body.MiniBlocks {
+	for mbIndex, miniblock := range body.MiniBlocks {
+		if shouldIgnoreProcessedMBScheduled(header, mbIndex) {
+			continue
+		}
+
 		shouldIgnore := isCrossShardAtSourceNormalTx(selfShardID, miniblock)
 		if shouldIgnore {
 			// ignore cross-shard miniblocks at source with normal txs


### PR DESCRIPTION
- Added extra information in bulk response 
- Ignore processed scheduled miniblocks in case of rollback ( the same behavior as the indexing part - transactions are indexed when are scheduled executed)  